### PR TITLE
Include a skipPack parameter to receive responses in JSON only

### DIFF
--- a/api/controllers/appbuilder/model-get.js
+++ b/api/controllers/appbuilder/model-get.js
@@ -46,6 +46,7 @@ var inputParams = {
    // limit: the number or entries to return.
 
    disableMinifyRelation: { optional: true },
+   skipPack: { bool: true, optional: true },
 
    //// For API Object: to pull data from the URL
    isAPI: { optional: true },
@@ -88,10 +89,12 @@ module.exports = function (req, res) {
    let jobData = {
       objectID: req.ab.param("objID"),
       cond: {},
+      skipPack: req.ab.param("skipPack") || false,
    };
 
+   let skipParams = ["objID", "skipPack"];
    Object.keys(inputParams).forEach((f) => {
-      if (f == "objID") return;
+      if (skipParams.indexOf(f) != -1) return;
       var val = req.ab.param(f);
       if (typeof val != "undefined") {
          try {

--- a/api/controllers/appbuilder/model-post.js
+++ b/api/controllers/appbuilder/model-post.js
@@ -12,6 +12,7 @@
  */
 var inputParams = {
    objID: { string: { uuid: true }, required: true },
+   skipPack: { bool: true, optional: true },
 };
 
 const BroadcastManager = require("../../lib/broadcastManager");
@@ -53,6 +54,7 @@ module.exports = function (req, res) {
       objectID: req.ab.param("objID"),
       values: {},
       // relocate the rest of the params as .values
+      skipPack: req.ab.param("skipPack") || false,
    };
 
    // add in anything else we just want to pass along:

--- a/api/controllers/appbuilder/model-update.js
+++ b/api/controllers/appbuilder/model-update.js
@@ -18,6 +18,7 @@ var inputParams = {
    /*    "email": { string:{ email: { allowUnicode: true }}, required:true }   */
    /*                -> NOTE: put .string  before .required                    */
    /*    "param": { required: true } // NOTE: param Joi.any().required();      */
+   skipPack: { bool: true, optional: true },
 };
 
 // make sure our BasePath is created:
@@ -51,6 +52,7 @@ module.exports = function (req, res) {
       objectID: req.ab.param("objID"),
       ID: req.ab.param("ID"),
       values: {},
+      skipPack: req.ab.param("skipPack") || false,
    };
 
    // Now collect any remaining Values and use them for the UPDATE data:


### PR DESCRIPTION
For use in the HR Update app to receive responses without our CSV compression.